### PR TITLE
Additional app update options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "steamcmd-interface",
-  "version": "2.1.6",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steamcmd-interface",
-  "version": "2.1.6",
+  "version": "3.0.0",
   "keywords": [
     "node",
     "steamcmd",

--- a/src/SteamCmd.js
+++ b/src/SteamCmd.js
@@ -175,31 +175,31 @@ export class SteamCmd {
    * instance.
    * @param {Object} [options] A set of options that affect how SteamCmd works.
    * @param {string} [options.binDir] The absolute path to where the Steam CMD
-   * executable will be downloaded to. Defaults to "steamcmd_bin" in the
+   * executable will be downloaded to. Defaults to "temp/steamcmd_bin" in the
    * current directory.
    * @param {string} [options.installDir] The absolute path to where Steam apps
-   * will be installed to. Defaults to "install_dir" in the current directory.
-   * @param {string} [options.username] The username to log into Steam.
-   * Defaults to 'anonymous'.
-   * @param {boolean} [enableDebugLogging = false] Whether or not all output of
-   * Steam CMD will be logged to the console. This is useful for debugging.
+   * will be installed to. Defaults to "temp/install_dir" in the current
+   * directory.
+   * @param {string} [options.username='anonymous'] The username to log into
+   * Steam.
+   * @param {boolean} [options.enableDebugLogging = false] Whether or not all
+   * output of Steam CMD will be logged to the console. This is useful for
+   * debugging.
    * @returns {Promise<SteamCmd>} Resolves into a ready-to-be-used SteamCmd
    * instance
    */
-  static async init (options, enableDebugLogging = false) {
+  static async init ({
+    binDir = path.join(__dirname, '../temp', 'steamcmd_bin', process.platform),
+    installDir = path.join(__dirname, '../temp', 'install_dir'),
+    username = 'anonymous',
+    enableDebugLogging = false
+  } = {}) {
     // Set the `initialising` variable to true to indicate to the constructor
     // that it's being legally called.
     SteamCmd.#initialising = true
 
-    const allOptions = Object.assign({
-      binDir: path.join(__dirname, '../temp', 'steamcmd_bin', process.platform),
-      installDir: path.join(__dirname, '../temp', 'install_dir'),
-      username: 'anonymous'
-    }, options)
-
     // Construct the new SteamCmd instance
-    const steamCmd = new SteamCmd(allOptions.binDir, allOptions.installDir,
-      allOptions.username)
+    const steamCmd = new SteamCmd(binDir, installDir, username)
 
     steamCmd.enableDebugLogging = enableDebugLogging
 
@@ -324,7 +324,7 @@ export class SteamCmd {
       await fs.promises.chmod(this.exePath, 0o755)
     } catch (error) {
       // If the executable's permissions couldn't be set then throw an error.
-      throw new Error("Steam CMD executable's permissions could not be set")
+      throw new Error('Steam CMD executable\'s permissions could not be set')
     }
 
     try {

--- a/src/SteamCmd.js
+++ b/src/SteamCmd.js
@@ -376,11 +376,16 @@ export class SteamCmd {
    * @throws {SteamCmdError} Throws an error if the Steam CMD executable quit
    * with a non-zero exit code.
    */
-  async * run (commands, options = {}) {
+  async * run (
+    commands,
+    {
+      noAutoLogin = false
+    } = {}
+  ) {
     const allCommands = [
       '@ShutdownOnFailedCommand 1',
       '@NoPromptForPassword 1',
-      options.noAutoLogin ? '' : `login "${this.#username}"`,
+      noAutoLogin ? '' : `login "${this.#username}"`,
       ...commands,
       'quit'
     ]

--- a/tests/steam-cmd.test.js
+++ b/tests/steam-cmd.test.js
@@ -21,7 +21,7 @@ let steamCmd
 function calculateDownloadTimeout (downloadSize) {
   /** Download speed in bits per second */
   const DOWNLOAD_SPEED = 9_000_000
-  const SAFETY_FACTOR = 1.5
+  const SAFETY_FACTOR = 3
 
   return downloadSize / (DOWNLOAD_SPEED / 8) * 1000 * SAFETY_FACTOR
 }
@@ -49,7 +49,11 @@ global.test(
   async () => {
     // Download the Source SDK Base 2013 Dedicated Server. This is the smallest
     // app I could find that may be downloaded anonymously.
-    const download = steamCmd.updateApp(244310, 'linux', 64)
+    const download = steamCmd.updateApp(244310, {
+      platformType: 'linux',
+      platformBitness: 64,
+      betaName: 'prerelease'
+    })
 
     for await (const { state, progressPercent } of download) {
       console.log(`Update state: ${state} ${progressPercent.toFixed(2)}%`)

--- a/tests/steam-cmd.test.js
+++ b/tests/steam-cmd.test.js
@@ -31,7 +31,7 @@ global.beforeAll(
     const tempDir = path.join(__dirname, '../temp')
     await fs.promises.rmdir(tempDir, { recursive: true })
 
-    steamCmd = await SteamCmd.init()
+    steamCmd = await SteamCmd.init({ enableDebugLogging: true })
   },
   // SteamCMD downloads about 20MB on first launch. Set the timeout accordingly.
   calculateDownloadTimeout(20_000_000)


### PR DESCRIPTION
# Changes
- In the `init` function moved the `enableDebugLogging` argument into the `options` object
- Added additional options to `updateApp`
  - Added ability to specify the language, beta name, beta password, and whether to validate the installation
- Updated tests

Closes #18 